### PR TITLE
Allow Nette 3.0 stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
 		"latte/latte": "~2.4 || ~3.0"
 	},
 	"require-dev": {
-		"nette/tester": "~1.6.1",
-		"mockery/mockery": "~0.9",
+		"nette/tester": "~2.0",
+		"mockery/mockery": "~1.0",
 		"tracy/tracy": "^2.4"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
 	},
 	"require": {
 		"php": ">= 7.1",
-		"nette/utils": "~2.4 || ~3.0@rc",
-		"nette/di": "~2.4 || ~3.0@rc",
-		"nette/application": "~2.4 || ~3.0@rc",
-		"nette/mail": "~2.4 || ~3.0@rc",
-		"latte/latte": "~2.4 || ~3.0@rc"
+		"nette/utils": "~2.4 || ~3.0",
+		"nette/di": "~2.4 || ~3.0",
+		"nette/application": "~2.4 || ~3.0",
+		"nette/mail": "~2.4 || ~3.0",
+		"latte/latte": "~2.4 || ~3.0"
 	},
 	"require-dev": {
 		"nette/tester": "~1.6.1",

--- a/tests/Unit/MailTest.phpt
+++ b/tests/Unit/MailTest.phpt
@@ -6,6 +6,7 @@ namespace Ublaboo\Mailing\Tests\Unit;
 
 use Mockery;
 use Tester\Assert;
+use Tester\Environment;
 use Tester\TestCase;
 use Ublaboo\Mailing\DI\MailingExtension;
 use Ublaboo\Mailing\Exception\MailingException;
@@ -13,6 +14,7 @@ use Ublaboo\Mailing\MailFactory;
 use Ublaboo\Mailing\Tests\Unit\TestingMailData;
 
 require __DIR__ . '/../bootstrap.php';
+Environment::bypassFinals();
 
 final class MailTest extends TestCase
 {


### PR DESCRIPTION
Relaxed composer.json to allow installation with `stable` minimum stability.