### PR TITLE
MailLogger: set more_entropy to uniqid()

### DIFF
--- a/src/MailLogger.php
+++ b/src/MailLogger.php
@@ -41,7 +41,7 @@ class MailLogger implements ILogger
 		if (file_exists($file) && filesize($file)) {
 			$file = str_replace(
 				static::LOG_EXTENSION,
-				'.' . uniqid() . static::LOG_EXTENSION,
+				'.' . uniqid('', true) . static::LOG_EXTENSION,
 				$file
 			);
 		}


### PR DESCRIPTION
I noticed that some emails don't log. Probably a problem is with the uniqid() function.

This function does not guarantee uniqueness of return value. Since most systems adjust system clock by NTP or like, system time is changed constantly. Therefore, it is possible that this function **does not return unique ID for the process/thread**. Use more_entropy to increase likelihood of uniqueness.